### PR TITLE
Update gx52 runtime to 46

### DIFF
--- a/com.leinardi.gx52.json
+++ b/com.leinardi.gx52.json
@@ -2,7 +2,7 @@
   "app-id": "com.leinardi.gx52",
   "command": "gx52",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "44",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "finish-args": [
     "--share=ipc",


### PR DESCRIPTION
- Update gx52 runtime to 46 since runtime version 44 has reached end-of-life.